### PR TITLE
define white background on TD

### DIFF
--- a/src/underwear.css
+++ b/src/underwear.css
@@ -371,6 +371,7 @@ tr:last-of-type > td:last-of-type {
 
 td {
   border-top: 0.1rem solid var(--table-border-color);
+  background-color: var(--white);
 }
 
 tbody > tr:last-of-type > td {


### PR DESCRIPTION
Define a white background on TD, so that the table cells (not table headers) will always have a white background, despite the background of the container

This is required to implement white table "HEADERS" on a gray section background, as in the design:

![all routes 1](https://user-images.githubusercontent.com/566463/36736073-f659dff2-1bd7-11e8-8c23-af89ffcd5f66.png)

Adding it to Underwear.css allows to remove this hack: https://github.com/Starcounter/Blending/blob/00ee20e12097ba6f7a698d461f224c19d57fb879/src/BlendingEditor/wwwroot/BlendingEditor/css/blendingeditor.css#L3