### PR TITLE
Set `box-sizing: border-box` on all elements (#58)

### DIFF
--- a/src/underwear.css
+++ b/src/underwear.css
@@ -107,11 +107,10 @@
 *,
 *:after,
 *:before {
-  box-sizing: inherit;
+  box-sizing: border-box;
 }
 
 html {
-  box-sizing: border-box;
   font-size: 62.5%;
 }
 
@@ -157,7 +156,6 @@ input[type='submit'] {
   padding-right: 16px;
   height: 32px;
   cursor: pointer;
-  box-sizing: border-box;
   white-space: nowrap;
   min-width: 120px;
   box-shadow: 0px 1px 3px 0 var(--shadow-color);
@@ -252,7 +250,6 @@ textarea {
   background-color: var(--editable-background-color);
   border: none;
   box-shadow: none;
-  box-sizing: border-box;
   height: 38px;
   padding-left: 16px;
   padding-right: 20px;


### PR DESCRIPTION
This is the same approach [done by Bootstrap 4](https://github.com/twbs/bootstrap/blob/33f3ba33c208937a2aec30accddc6b7384442c6b/scss/_reboot.scss#L21-L25)

Solves #58 

I have manually tested with Underwear.css in Chrome and there is no difference in rendering.

I have manually tested with Uniform.css in Chrome, and there is one difference, which is an improvement in my opinion:

Before this PR:

![image](https://user-images.githubusercontent.com/566463/36738171-30754f28-1bdd-11e8-936f-e40435788bb1.png)

After this PR:

![image](https://user-images.githubusercontent.com/566463/36738179-357cf8e0-1bdd-11e8-9dff-203b870ee35d.png)
