### PR TITLE
Fix for: Border in table is not applied to last <td> if its inside a dom-if (#63)

### DIFF
--- a/src/underwear.css
+++ b/src/underwear.css
@@ -375,11 +375,11 @@ tbody > tr:last-of-type > td {
   border-bottom: 0.1rem solid var(--table-border-color);
 }
 
-td:first-child {
+td:first-of-type {
   border-left: 0.1rem solid var(--table-border-color);
 }
 
-td:last-child {
+td:last-of-type {
   border-right: 0.1rem solid var(--table-border-color);
 }
 


### PR DESCRIPTION
Change the selector to `:last-of-type`

because otherwise, it did not apply if there was a `<template>` as the last element of `<tr>`

Solves #63 